### PR TITLE
Footer - add case for GLA site; clarify sites listing text

### DIFF
--- a/app/views/help/_resources.html.erb
+++ b/app/views/help/_resources.html.erb
@@ -34,6 +34,12 @@
 	     and puts these materials together in a faceted search-and-browse interface. These objects themselves are accessible via links to the
 	     <a class="nav_link" href="//www.nines.org/about/wp-content/uploads/2011/12/9swhitepaper.pdf" target="_blank">federated</a>
          websites that have contributed them.
+       <% elsif SKIN.upcase === 'GLA' %>
+          <span class="emph2">The Great Lakes Aggregator project</span> vets freely-available digital objects concerning
+          all aspects of the Great Lakes Basin and gathers metadata (descriptive information) about them into a single interface for
+          search, browsing, and independent collation. The objects themselves are available via link to the
+          <a class="nav_link" href="//www.nines.org/about/wp-content/uploads/2011/12/9swhitepaper.pdf" target="_blank">federated</a>
+          websites that have contributed them.
 	   <% else %>
          <span class="emph2">
            In essence,

--- a/app/views/help/_sites.html.erb
+++ b/app/views/help/_sites.html.erb
@@ -16,7 +16,8 @@
     # ---------------------------------------------------------------------------- -%>
 <div style="width:900px;">
 	<div class="popup">
-	<p><span class="emph2">Scholarly projects participating in <%= Setup.site_name() %>/Collex include:</span>
+	<p>The <%= Setup.site_name() %> project is just one node in the larger ARC project, a network of aggregators utilizing
+      the same underlying technologies. A list of all scholarly projects participating in this initiative appear below:
 	<table class="small_list">
 		<% @sites.each_with_index do |site, index|%>
 			<% if index % 3 == 0 %>

--- a/app/views/help/_sites.html.erb
+++ b/app/views/help/_sites.html.erb
@@ -16,8 +16,14 @@
     # ---------------------------------------------------------------------------- -%>
 <div style="width:900px;">
 	<div class="popup">
-	<p>The <%= Setup.site_name() %> project is just one node in the larger ARC project, a network of aggregators utilizing
-      the same underlying technologies. A list of all scholarly projects participating in this initiative appear below:
+	<p>
+	<% if SKIN.upcase == "GLA" %>
+		The <%= Setup.site_name() %> project is just one node in the larger ARC project, a network of 
+		aggregators utilizing the same underlying technologies. A list of all scholarly projects 
+		participating in this initiative appear below:
+	<% else %>
+		<span class="emph2">Scholarly projects participating in <%= Setup.site_name() %>/Collex include:</span>
+	<% end %>
 	<table class="small_list">
 		<% @sites.each_with_index do |site, index|%>
 			<% if index % 3 == 0 %>


### PR DESCRIPTION
Hello!

Don't know how amenable the project is to third-party PRs, but in case you are:
I'm one of the folks running the [GLA](http://www.greatlakescollections.org/) arc node - we were having issues with users being confused by the footer popup text, largely since it mischaracterizes the site as a collector of 19th-century literature studies material. The "sites" section of the footer also seemed to be implying that all the 100+ sites displayed were part of the GLA project specifically, when we're only indexing 4 or 5.

The changes made in this PR should help clarify the issue.